### PR TITLE
Add Basic Project Infrastructure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# What
+> Describe at a high level what changes are in this Pull Request.
+>
+> Delete this callout.
+
+# Why
+> Describe why your are making these changes especially their value.
+>
+> Delete this callout.
+
+# Change Impact Analysis and Testing
+> Describe the specific impacts of your changes and how those impacts
+> will be vetted.
+>
+> Delete this callout.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore bundler config.
+/.bundle
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Exclude any environment variable dirs/files in root
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,22 +9,19 @@ FROM ${BASE_IMAGE} AS ruby-alpine
 #--- Builder Stage ---
 FROM ruby-alpine AS builder
 
-# Alpine needs build-base for building native extensions
+# NOTE: Currently, no additional build packages are needed
 ARG BUILD_PACKAGES='build-dependencies build-base'
 
 # Use the same version of Bundler in the Gemfile.lock
 ARG BUNDLER_VER=2.4.9
 
-# TODO: Determine needed packages
-# RUN apk --update add --virtual ${BUILD_PACKAGES} \
-  # Update gem command to latest
-  # Update gem command to latest
+# Update gem command to latest
 RUN gem update --system \
   # && gem update --system \
   && gem install bundler:${BUNDLER_VER}
 
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
-WORKDIR /app
+WORKDIR /tests
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
@@ -54,8 +51,8 @@ USER deployer
 COPY --from=builder --chown=deployer /usr/local/bundle/ /usr/local/bundle/
 
 # Copy the app source to /app
-WORKDIR /app
-COPY --chown=deployer . /app/
+WORKDIR /tests
+COPY --chown=deployer . /tests/
 
 # Run the tests but allow override
 CMD ./script/run tests

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |_repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.1'
 
+gem 'bundler-audit', require: false
 gem 'faker'
 gem 'faraday'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     faker (3.1.1)
@@ -51,6 +54,7 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    thor (1.2.1)
     unicode-display_width (2.4.2)
 
 PLATFORMS
@@ -58,6 +62,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bundler-audit
   faker
   faraday
   rspec

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# WIP: random_thoughts_api_e2e
+
+> **This is a Work In Progress**
+
+This is the Acceptance Test/End-To-End (E2E) Test suite for the
+[random_thoughts_api](https://github.com/brianjbayer/random_thoughts_api)
+application.
+
+Tests include...
+* Testing the health check endpoints of the
+  `random_thoughts_api`
+
+* Testing an end-to-end scenario of...
+  1. Creating a new random_thoughts_api user
+  2. Logging in the new user
+  3. Having the logged in new user create a random thought
+  4. Listing the random thoughts and verifying that the new
+     user's random thought is present
+
+This test suite is intended to **supplement** the functional
+tests in the `random_thoughts_api` project and provide a
+basic functional "smoke test" for the application.
+
+## Required Environment Variables
+You must specify the base URL (e.g. http://localhost:3000) for
+the target `random_thoughts_api` application under test using the
+`E2E_BASE_URL` environment variable.
+
+## Operating
+Assuming that you have set or are supplying the `E2E_BASE_URL`
+environment variable, run the following command to run the tests...
+```
+./script/run tests
+```
+
+This project is configured so that you can re-run just the
+failing tests using the RSpec `--only-failures` (or
+`--next-failure`) option.
+```
+./script/run tests --only-failures
+```
+
+### Code Style/Linting
+This project includes the Rubocop gems
+[`rubocop`](https://github.com/rubocop/rubocop),
+[`rubocop-rspec`](https://github.com/rubocop/rubocop-rspec)
+for linting and ensuring a consistent code style.
+
+Run the following command to run code style/linting...
+```
+./script/run lint
+```
+
+### Dependency Static Security Scanning
+This project includes the
+[`bundler-audit`](https://github.com/rubysec/bundler-audit)
+gem for statically scanning the gems for any known security
+vulnerabilities.
+
+Run the following command to run the dependency security scan...
+```
+./script/run secscan
+```
+
+## Specifications
+### Versions
+* Ruby: 3.2.1
+* RSpec 3
+
+### Support
+* [RSpec](http://rspec.info/) - Test Framework
+* [Faker](https://github.com/faker-ruby/faker) - Test Data
+* [bundler-audit](https://github.com/rubysec/bundler-audit) - Dependency
+  Static Security
+* [rubocop](https://github.com/rubocop/rubocop),
+  [rubocop-rspec](https://github.com/rubocop/rubocop-rspec) - Code Style
+  and Linting

--- a/script/run
+++ b/script/run
@@ -1,0 +1,72 @@
+#!/bin/sh
+# -----------------------------------------------
+# Project run script to run
+#   - lint
+#   - secscan
+#   - tests
+#   - or it runs all arguments
+# -----------------------------------------------
+
+# --- Functions ---
+run_and_exit_return_code () {
+  # Exit script on any errors
+  set -e
+
+  # Set to all positional parameters each expanding
+  # to a separate word
+  command_to_run="$@"
+  if [ -z "$command_to_run" ]; then
+    echo "ERROR: Function requires a command argument (86)"
+    exit 86
+  fi
+
+  # Run the command and preserve exit code
+  echo "RUNNING [${command_to_run} ]..."
+  # Allow to fail but catch return code
+  set +e
+  $command_to_run
+  run_return_code=$?
+  # NOTE return code must be caught before any other command
+  set -e
+  echo ''
+
+  echo "EXITING WITH RUN RETURN CODE [${run_return_code}]"
+  exit $run_return_code
+}
+
+# ------------
+# --- MAIN ---
+# ------------
+# Exit script on any errors
+set -e
+
+# set run command if recognized action
+action="${1}"
+case "$action" in
+  "lint")
+    shift
+    run_command="bundle exec rubocop $@"
+  ;;
+
+  "secscan")
+    shift
+    run_command="bundle exec bundle-audit check --update $@"
+  ;;
+
+  "tests")
+    shift
+    run_command="bundle exec rspec $@"
+  ;;
+esac
+
+if [ -z "$run_command" ]; then
+  # No recognized actions so run all the arguments as the command"
+  run_command="$@"
+else
+  echo "RUNNING Action [${action}]"
+fi
+
+# Run the command and exit passing any arguments
+run_and_exit_return_code "$run_command"
+echo "ERROR: should have exited!!! (99)"
+exit 99

--- a/tmp/examples.txt
+++ b/tmp/examples.txt
@@ -1,7 +1,0 @@
-example_id                                                   | status | run_time        |
------------------------------------------------------------- | ------ | --------------- |
-./spec/features/new_user_creates_random_thought_spec.rb[1:1] | passed | 2.34 seconds    |
-./spec/health_checks/live_check_spec.rb[1:1]                 | passed | 0.01444 seconds |
-./spec/health_checks/live_check_spec.rb[1:2]                 | passed | 0.00508 seconds |
-./spec/health_checks/ready_check_spec.rb[1:1]                | passed | 0.00739 seconds |
-./spec/health_checks/ready_check_spec.rb[1:2]                | passed | 0.03089 seconds |


### PR DESCRIPTION
# What
This changeset adds some basic infrastructure to this project, specifically..
- Adding `bundler-audit` gem for dependency security scanning
- Adding a `.gitignore` file
- Adding a `run` script
- Adding a README
- Adding a Pull Request (PR)template
- Cleaning up the Dockerfile

# Why
This added project infrastructure should aid in using and developing this project.

# Change Impact Analysis and Testing

- [x] Dockerfile was built for deploy and development environment
- [x] Manual testing of the `run` script
- [x] Manual inspection of the README on the branch
