### PR TITLE
Make Health Check Tests More Resilient by Comparing JSON Responses as Hashes

### DIFF
--- a/spec/health_checks/live_check_spec.rb
+++ b/spec/health_checks/live_check_spec.rb
@@ -3,8 +3,11 @@
 require 'spec_helper'
 
 class LivezResponse
-  def self.body_json
-    '{ "status": 200, "message": "alive" }'
+  def self.body
+    {
+      'status' => 200,
+      'message' => 'alive'
+    }
   end
 end
 
@@ -15,7 +18,8 @@ RSpec.describe '/livez' do
     expect(livez_request.status).to be(200)
   end
 
-  it "returns expected JSON [#{LivezResponse.body_json}]" do
-    expect(livez_request.body).to eql(LivezResponse.body_json)
+  it "returns expected JSON [#{LivezResponse.body.to_json}]" do
+    # Ignore format and order
+    expect(JSON.parse(livez_request.body)).to eql(LivezResponse.body)
   end
 end

--- a/spec/health_checks/ready_check_spec.rb
+++ b/spec/health_checks/ready_check_spec.rb
@@ -3,8 +3,12 @@
 require 'spec_helper'
 
 class ReadyZResponse
-  def self.body_json
-    '{"status":200,"message":"ready","database_connection":"ok"}'
+  def self.body
+    {
+      'status' => 200,
+      'message' => 'ready',
+      'database_connection' => 'ok'
+    }
   end
 end
 
@@ -15,7 +19,7 @@ RSpec.describe '/readyz' do
     expect(readyz_request.status).to be(200)
   end
 
-  it "returns expected JSON [#{ReadyZResponse.body_json}]" do
-    expect(readyz_request.body).to eql(ReadyZResponse.body_json)
+  it "returns expected JSON [#{ReadyZResponse.body.to_json}]" do
+    expect(JSON.parse(readyz_request.body)).to eql(ReadyZResponse.body)
   end
 end


### PR DESCRIPTION
# What
This changeset changes the health check tests to compare the JSON response as a hash to ignore order and format.

# Why
By comparing the JSON response as a hash any differences in order and/or format are ignored making the tests less brittle. 

# Change Impact Analysis and Testing

- [x] Manually ran the tests against different formatted responses
