### PR TITLE
Increase Understanding When Tests Fail by Adding Custom Response Matchers with Better Messaging

### DIFF
--- a/spec/features/new_user_creates_random_thought_spec.rb
+++ b/spec/features/new_user_creates_random_thought_spec.rb
@@ -6,14 +6,13 @@ require_relative '../support/helpers/auth_helper'
 require_relative '../support/helpers/random_thought_helper'
 require_relative '../support/helpers/user_helper'
 
-# rubocop:disable RSpec/InstanceVariable, RSpec/NoExpectationExample, Metrics/AbcSize
-# Disabling above Cops because...
+# Disabling following Cops because...
 #   1. Instance variables are needed in order to ensure created user is deleted
 #      in the after block which is run even if test fails
 #   2. Using the private methods which have the exceptions helps make the test
-#      more understandable
-#   3. All necessary steps and assertions are kept grouped together in the
-#      private methods
+#      intent more understandable
+
+# rubocop:disable RSpec/InstanceVariable, RSpec/NoExpectationExample
 RSpec.describe 'New User Creates Random Thought' do
   include AuthHelper
   include RandomThoughtHelper
@@ -23,64 +22,84 @@ RSpec.describe 'New User Creates Random Thought' do
   let(:new_random_thought) { build_random_thought }
 
   after do
-    delete_user_request(@user_id, @user_jwt)
+    delete_user_request(@user_id, @user_jwt) if @user_id.is_a?(Integer) && @user_jwt
   end
 
   it 'Can create user, log in, and create random thought' do |example|
-    new_user_creates_account(example.reporter)
-    new_user_logs_in(example.reporter)
-    new_user_creates_random_thought(example.reporter)
-    new_random_thought_is_listed(example.reporter)
+    can_create_new_user(example.reporter)
+    new_user_can_log_in(example.reporter)
+    new_user_can_create_random_thought(example.reporter)
+    can_list_new_random_thought(example.reporter)
   end
 
   private
 
-  def new_user_creates_account(reporter)
-    reporter.message('Create new user...')
-    creating_new_user = create_user_request(new_user)
-    expect(creating_new_user.status).to be(201)
+  # --- "Steps" ---
+  def can_create_new_user(reporter)
+    reporter.message('Can create new user...')
+    create_new_user_response = create_user_request(new_user)
+
+    # Need an id value for response matcher
+    @user_id = create_new_user_response.body['id'] || 'IGNORE WHEN FAILS'
+    expect(create_new_user_response).to be_request_response(201, created_user_response(@user_id, new_user))
     reporter.message('...New user created')
-    @user_id = creating_new_user.body['id']
-    expect(@user_id).to be_truthy
-    expect(creating_new_user.body['email']).to eql(new_user.email)
-    expect(creating_new_user.body['display_name']).to eql(new_user.display_name)
   end
 
-  def new_user_logs_in(reporter)
-    reporter.message('Log in new user...')
-    logging_in_new_user = login_user_request(new_user)
+  def new_user_can_log_in(reporter)
+    reporter.message('New user can log in...')
+    log_in_user_response = login_user_request(new_user)
 
-    expect(logging_in_new_user.status).to be(200)
-    reporter.message('...New user logged in')
-    @user_jwt = logging_in_new_user.body['token']
-    expect(@user_jwt).to be_truthy
-    expect(logging_in_new_user.body['message']).to include('success')
+    # Need a token value for response matcher
+    jwt = log_in_user_response.body['token'] || 'IGNORE WHEN FAILS'
+    expect(log_in_user_response).to be_request_response(200, logged_in_response(jwt))
+    reporter.message('...New user is logged in')
+    # If success set this for creating random thought and deleting user in after block
+    @user_jwt = jwt
   end
 
-  def new_user_creates_random_thought(reporter)
-    reporter.message('New user creates random thought...')
-    creating_new_random_thought = create_random_thought_request(new_random_thought, @user_jwt)
+  def new_user_can_create_random_thought(reporter)
+    reporter.message('New user can create random thought...')
+    create_new_random_thought_response = create_random_thought_request(new_random_thought, @user_jwt)
 
-    expect(creating_new_random_thought.status).to be(201)
-    reporter.message('...Random thought created')
-    @random_thought_id = creating_new_random_thought.body['id']
-    expect(@random_thought_id).to be_truthy
-    expect(creating_new_random_thought.body['thought']).to eql(new_random_thought.thought)
-    expect(creating_new_random_thought.body['mood']).to eql(new_random_thought.mood)
+    # Need an id value for response matcher
+    @random_thought_id = create_new_random_thought_response.body['id'] || 'IGNORE WHEN FAILS'
+    created_random_thought = created_random_thought_response(@random_thought_id, new_random_thought, new_user)
+    expect(create_new_random_thought_response).to be_request_response(201, created_random_thought)
+    reporter.message('...Random thought is created')
   end
 
-  def new_random_thought_is_listed(reporter)
+  def can_list_new_random_thought(reporter)
     # ASSUMPTION: Random Thoughts Are Ordered By Most Recent First
-    reporter.message('List newest random thoughts...')
+    reporter.message('Can list random thought...')
     listing_random_thoughts = list_random_thoughts_request
 
-    expect(listing_random_thoughts.status).to be(200)
-    reporter.message('...Newest random thoughts listed')
-    users_random_thought = listing_random_thoughts.body['data'].find { |item| item['id'] == @random_thought_id }
-    expect(users_random_thought).not_to be_nil
-    reporter.message("Found user's random thought in listing")
-    expect(users_random_thought['thought']).to eql(new_random_thought.thought)
-    expect(users_random_thought['mood']).to eql(new_random_thought.mood)
+    expect(listing_random_thoughts).to include_random_thought(200, @random_thought_id, new_random_thought)
+    reporter.message('...Random thought found in listing')
+  end
+
+  # --- Expected Responses ---
+  def created_user_response(id, user)
+    {
+      'id' => id,
+      'email' => user.email,
+      'display_name' => user.display_name
+    }
+  end
+
+  def logged_in_response(jwt)
+    {
+      'token' => jwt,
+      'message' => 'User logged in successfully'
+    }
+  end
+
+  def created_random_thought_response(id, random_thought, user)
+    {
+      'id' => id,
+      'thought' => random_thought.thought,
+      'mood' => random_thought.mood,
+      'name' => user.display_name
+    }
   end
 end
-# rubocop:enable RSpec/InstanceVariable, RSpec/NoExpectationExample, Metrics/AbcSize
+# rubocop:enable RSpec/InstanceVariable, RSpec/NoExpectationExample

--- a/spec/health_checks/live_check_spec.rb
+++ b/spec/health_checks/live_check_spec.rb
@@ -2,24 +2,17 @@
 
 require 'spec_helper'
 
-class LivezResponse
-  def self.body
+RSpec.describe '/livez' do
+  subject(:livez_request) { random_thoughts_unauth_connection.get(endpoint_url('/livez')) }
+
+  it { expect(livez_request).to be_request_response(200, livez_response) }
+
+  private
+
+  def livez_response
     {
       'status' => 200,
       'message' => 'alive'
     }
-  end
-end
-
-RSpec.describe '/livez' do
-  subject(:livez_request) { Faraday.get(endpoint_url('/livez')) }
-
-  it 'returns status code 200' do
-    expect(livez_request.status).to be(200)
-  end
-
-  it "returns expected JSON [#{LivezResponse.body.to_json}]" do
-    # Ignore format and order
-    expect(JSON.parse(livez_request.body)).to eql(LivezResponse.body)
   end
 end

--- a/spec/health_checks/ready_check_spec.rb
+++ b/spec/health_checks/ready_check_spec.rb
@@ -2,24 +2,18 @@
 
 require 'spec_helper'
 
-class ReadyZResponse
-  def self.body
+RSpec.describe '/readyz' do
+  subject(:readyz_request) { random_thoughts_unauth_connection.get(endpoint_url('/readyz')) }
+
+  it { expect(readyz_request).to be_request_response(200, readyz_response) }
+
+  private
+
+  def readyz_response
     {
       'status' => 200,
       'message' => 'ready',
       'database_connection' => 'ok'
     }
-  end
-end
-
-RSpec.describe '/readyz' do
-  subject(:readyz_request) { Faraday.get(endpoint_url('/readyz')) }
-
-  it 'returns status code 200' do
-    expect(readyz_request.status).to be(200)
-  end
-
-  it "returns expected JSON [#{ReadyZResponse.body.to_json}]" do
-    expect(JSON.parse(readyz_request.body)).to eql(ReadyZResponse.body)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,8 @@ end
 require 'faker'
 require 'faraday'
 require_relative 'support/helpers/endpoint_helper'
+require_relative 'support/matchers/be_request_response'
+require_relative 'support/matchers/include_random_thought'
 
 RSpec.configure do |config|
   # Faker values are only guaranteed unique for each top level

--- a/spec/support/matchers/be_request_response.rb
+++ b/spec/support/matchers/be_request_response.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Custom RSpec Matcher to match an
+# expected request response
+module BeRequestResponse
+  class BeRequestResponse
+    def initialize(status, body)
+      @status = status
+      @body = body
+    end
+
+    def matches?(actual)
+      @actual_status = actual.status
+      @actual_body = actual.body
+
+      @actual_status == @status &&
+        @actual_body == @body
+    end
+
+    def failure_message
+      "expected that actual status code [#{@actual_status}] would match " \
+        "expected status code [#{@status}] and that actual body " \
+        "[#{pretty(@actual_body)}] would match expected body " \
+        "[#{pretty(@body)}]"
+    end
+
+    def failure_message_when_negated
+      "expected that actual status code [#{@actual_status}] would not match " \
+        "expected status code [#{@status}] and that actual body " \
+        "[#{pretty(@actual_body)}] would match expected body " \
+        "[#{pretty(@body)}]"
+    end
+
+    def description
+      "have response status code [#{@status}] and body [#{@body}]"
+    end
+
+    private
+
+    def pretty(json)
+      JSON.pretty_generate(json)
+    end
+  end
+
+  def be_request_response(status, body)
+    BeRequestResponse.new(status, body)
+  end
+end
+
+# Include the custom matcher in RSpec
+RSpec.configure do |config|
+  config.include BeRequestResponse
+end

--- a/spec/support/matchers/include_random_thought.rb
+++ b/spec/support/matchers/include_random_thought.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Custom RSpec Matcher to ensure
+# paginated index response contains
+# random thought
+
+module IncludeRandomThought
+  class IncludeRandomThought
+    def initialize(status, random_thought_id, random_thought)
+      @status = status
+      @id = random_thought_id
+      @random_thought = random_thought
+    end
+
+    def matches?(actual)
+      @actual_status = actual.status
+      @actual_body = actual.body
+
+      found_random_thought = @actual_body['data']&.find { |item| item['id'] == @id }
+
+      @actual_status == @status &&
+        found_random_thought &&
+        found_random_thought['thought'] == @random_thought.thought &&
+        found_random_thought['mood'] == @random_thought.mood
+    end
+
+    def failure_message
+      "expected that actual status code [#{@actual_status}] would match " \
+        "expected status code [#{@status}] and that actual body " \
+        "[#{pretty(@actual_body)}] would include a random_thought with " \
+        "id [#{@id}], thought [#{@random_thought.thought}], and " \
+        "mood [#{@random_thought.mood}]"
+    end
+
+    def failure_message_when_negated
+      "expected that actual status code [#{@actual_status}] would not match " \
+        "expected status code [#{@status}] and that actual body " \
+        "[#{pretty(@actual_body)}] would not include a random_thought with " \
+        "id [#{@id}], thought [#{@random_thought.thought}], and " \
+        "mood [#{@random_thought.mood}]"
+    end
+
+    private
+
+    def pretty(json)
+      JSON.pretty_generate(json)
+    end
+  end
+
+  def include_random_thought(status, random_thought_id, random_thought)
+    IncludeRandomThought.new(status, random_thought_id, random_thought)
+  end
+end
+
+# Include the custom matcher in RSpec
+RSpec.configure do |config|
+  config.include IncludeRandomThought
+end


### PR DESCRIPTION
# What
This changeset adds custom RSpec matchers for request responses and refactors the tests to use them.

# Why
By adding custom response matchers with better messaging, the actual responses will be presented giving better insight into why the tests are failing and what the system under test is returning.

# Change Impact Analysis and Testing
Run tests to ensure they work as expected...
- [x] Against the mock
- [x] Against the app
- [x] Run tests with forced faults to ensure failure message properly conveys the actual and expected responses. 
