### PR TITLE
Add Docker Compose Framework and Continuous Integration

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -1,0 +1,101 @@
+name: On PR Build Push Vet
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# FYI...
+#  Raw Branch Name: ${{ github.head_ref }}
+#  <commit-sha>: ${{ github.event.pull_request.head.sha }}
+
+# Produced images...
+#  1. (Always) Unvetted Image: <owner/repository>_<normalized-branch>_unvetted:<commit-sha>
+#  2. (Always) Dev Environment Image: <owner/repository>_<normalized-branch>_dev:<commit-sha>
+#  3. (If vetted) Vetted_image: <owner/repository>_<normalized-branch>:<commit-sha>
+
+jobs:
+  # Normalize the branch for image name
+  pr-norm-branch:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    with:
+      raw_name: ${{ github.head_ref }}
+
+  # Build and Push Images
+  build-and-push-branch-devenv:
+    needs: [pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    with:
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+      buildopts: --target devenv
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  build-and-push-branch-unvetted:
+    needs: [pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    with:
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  # Vet Deploy Image
+  vet-code-standards:
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun rubocop on development environment
+        run: "E2ETESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run lint"
+
+  vet-dependency-security:
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun bundle-audit on development environment
+        run: "E2ETESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run secscan"
+
+  vet-deploy-e2e-tests:
+    needs: [pr-norm-branch, build-and-push-branch-unvetted]
+    runs-on: ubuntu-latest
+    env:
+      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun unvetted image with mock target
+        run: "E2ETESTS_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -cm"
+
+# Push (IF) Vetted Deploy Image
+  push-branch-vetted-deploy-image:
+    needs:
+      - vet-code-standards
+      - vet-dependency-security
+      - vet-deploy-e2e-tests
+      - pr-norm-branch
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      # Pull unvetted branch image
+      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+      # Push Vetted Image
+      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  # Vet Dev Environment Image
+  vet-devenv-e2e-tests:
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun devenv image with mock target
+        run: "E2ETESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -dm ./script/run tests"

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -1,0 +1,75 @@
+name: On Merge Promote Branch Image to Prod
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  branch-and-last-commit:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@main
+
+  push-norm-branch:
+    needs: [branch-and-last-commit]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    with:
+      raw_name: ${{ needs.branch-and-last-commit.outputs.branch }}
+
+  branch-and-last-commit-merged-info:
+    needs: [branch-and-last-commit, push-norm-branch]
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_LAST_COMMIT: ${{ needs.branch-and-last-commit.outputs.commit }}
+      BRANCH: ${{ needs.branch-and-last-commit.outputs.branch }}
+      NORM_BRANCH: ${{ needs.push-norm-branch.outputs.name }}
+
+    steps:
+      - name: Output last commit of merged branch env var
+        run: echo "BRANCH_LAST_COMMIT=[${BRANCH_LAST_COMMIT}]"
+      - name: Output merged branch env var
+        run: echo "BRANCH=[${BRANCH}]"
+      - name: Output normalized merged branch env var
+        run: echo "NORM_BRANCH=[${NORM_BRANCH}]"
+
+  promote-branch-last-commit-to-prod:
+    needs: [branch-and-last-commit, push-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      # Pull last (vetted) branch image
+      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      # Push prod Image
+      push_as: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  promote-branch-last-commit-to-prod-latest:
+    needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: ${{ github.repository }}
+      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  promote-branch-last-commit-devenv:
+    needs: [branch-and-last-commit, push-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      # Pull last branch devenv image
+      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      # Push prod devenv image
+      push_as: ${{ github.repository }}-dev:${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  promote-branch-last-commit-devenv-to-latest:
+    needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: ${{ github.repository }}-dev
+      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# WIP: random_thoughts_api_e2e
-
-> **This is a Work In Progress**
+# random_thoughts_api_e2e
 
 This is the Acceptance Test/End-To-End (E2E) Test suite for the
 [random_thoughts_api](https://github.com/brianjbayer/random_thoughts_api)
@@ -21,10 +19,58 @@ This test suite is intended to **supplement** the functional
 tests in the `random_thoughts_api` project and provide a
 basic functional "smoke test" for the application.
 
+---
+
 ## Required Environment Variables
 You must specify the base URL (e.g. http://localhost:3000) for
 the target `random_thoughts_api` application under test using the
 `E2E_BASE_URL` environment variable.
+
+## Running
+
+> **Prerequisites**: You must have Docker installed and
+> running on your local machine
+
+The easiest way to run the tests is with the docker compose
+framework using the `dockercomposerun` script.
+
+This will pull the latest docker image of this project and run
+the tests against the target application specified with the
+`E2E_BASE_URL` environment variable.
+
+Assuming that you have set or supplied the `E2E_BASE_URL`
+environment variable to specify the target, to run the tests
+using the docker compose framework, run the following command...
+```
+./script/dockercomposerun
+```
+
+For example, to run the tests against a target running on your
+local (e.g. host) machine on port 3000, run the following
+command...
+```
+E2E_BASE_URL=http://host.docker.internal:3000 ./script/dockercomposerun
+```
+
+### Using the Mock Application as the Target of the Tests
+If you want to run the tests using the docker compose framework
+against the Mock application
+[mock_random_thoughts_api](https://github.com/brianjbayer/mock_random_thoughts_api)
+as the target, use the `-m` (mock) option with the
+`dockercomposerun` script.  This will pull the pinned tagged
+image of the mock application and run the tests against it.
+
+To run the tests using the docker compose framework against the
+mock application container, run the following command...
+```
+./script/dockercomposerun -m
+```
+
+> :point_right: When using the `-m` option, the value of the
+> `E2E_BASE_URL` environment variable will be overridden
+> in the docker compose framework
+
+---
 
 ## Operating
 Assuming that you have set or are supplying the `E2E_BASE_URL`
@@ -42,7 +88,7 @@ failing tests using the RSpec `--only-failures` (or
 
 ### Code Style/Linting
 This project includes the Rubocop gems
-[`rubocop`](https://github.com/rubocop/rubocop),
+[`rubocop`](https://github.com/rubocop/rubocop) and
 [`rubocop-rspec`](https://github.com/rubocop/rubocop-rspec)
 for linting and ensuring a consistent code style.
 
@@ -61,6 +107,58 @@ Run the following command to run the dependency security scan...
 ```
 ./script/run secscan
 ```
+
+---
+## Development
+This project can be developed using the supplied container-based
+development environment which includes `vim` and `git`.
+
+The development environment container volume mounts your local source
+code to recognize and persist any changes.
+
+By default the development environment container executes the alpine
+`/bin/ash` shell providing a command line interface.
+
+### To Develop Using the Container-Based Development Environment
+The easiest way to run the containerized development environment is with
+the docker compose framework using the `dockercomposerun` script with the
+`-d` (development environment) option...
+```
+./script/dockercomposerun -d
+```
+
+This will pull and run the latest development environment image of this
+project.
+
+> :bulb: You can use the Mock application in the docker compose
+> framework development environment by specifying the `-m`
+> option (e.g. `./script/dockercomposerun -dm`)
+
+#### Building Your Own Development Environment Image
+You can also build and run your own development environment image.
+
+1. Build your development environment image specifying the `devenv` build
+   stage as the target and supplying a name (tag) for the image.
+   ```
+   docker build --no-cache --target devenv -t rta-e2e-dev .
+   ```
+
+2. Run your development environment image in the docker-compose
+   environment and specify your development environment image
+   with `E2ETESTS_IMAGE`
+   ```
+   E2ETESTS_IMAGE=rta-e2e-dev ./script/dockercomposerun -d
+   ```
+
+#### Specifying the Source Code Location
+To use another directory as the source code for the development
+environment, set the `E2ETESTS_SRC` environment variable.
+For example...
+```
+E2ETESTS_SRC=${PWD} E2ETESTS_IMAGE=rta-e2e-dev ./script/dockercomposerun -d
+```
+
+---
 
 ## Specifications
 ### Versions

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,4 @@
+version: '3.8'
+services:
+  e2etests:
+    image: "${E2ETESTS_IMAGE}"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  e2etests:
+    image: "${E2ETESTS_IMAGE:-brianjbayer/random_thoughts_api_e2e-dev:latest}"
+    volumes:
+      - ${E2ETESTS_SRC:-.}:/test

--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  e2etests:
+    environment:
+      - E2E_BASE_URL=http://${MOCK_HOSTNAME:-mock}:${MOCK_PORT:-3000}
+    depends_on:
+      mock:
+        condition: service_healthy
+
+  mock:
+  # NOTE: Pin tag to ensure version matching between tests and mock
+    image: ${MOCK_IMAGE:-brianjbayer/mock_random_thoughts_api:930220310635932c4e40c442ce6db9f81af11cc7}
+    container_name: ${MOCK_HOSTNAME:-mock}
+    environment:
+      - PORT=${MOCK_PORT:-3000}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${MOCK_PORT:-3000}/readyz"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  e2etests:
+    image: brianjbayer/random_thoughts_api_e2e:${E2ETESTS_TAG:-latest}
+    container_name: ${E2ETESTS_HOSTNAME:-e2etests}
+    environment:
+      - E2E_BASE_URL

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,0 +1,128 @@
+#!/bin/sh
+# This script runs the project docker-compose framework.
+#
+# - The arguments to this script are passed to the e2etests service
+#   as command override
+#
+# - Any environment variables set when calling this script are passed
+#   through to the docker-compose framework
+#   (e.g. configuration other than the defaults)
+#
+# OPTIONS:
+# -c: Use the docker-compose CI environment with E2ETESTS_IMAGE
+# -d: Use the docker-compose Dev environment with E2ETESTS_IMAGE
+# -m: Use the mock application as the target
+# ----------------------------------------------------------------------
+
+usage() {
+  echo "Usage: $0 [-cdmn] [CMD]"
+}
+
+err_exit() {
+  local err_msg="$1"
+  local err_code=$2
+  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
+  usage
+  exit $err_code
+}
+
+# Exit script on any errors
+set -e
+
+# Handle options
+while getopts ":cdm" options; do
+  case "${options}" in
+    c)
+      echo "CI Environment"
+      ci=true
+      ;;
+
+    d)
+      echo "Development Environment"
+      devenv=true
+      ;;
+
+    m)
+      echo "Use Mock as Target"
+      usemock=true
+      ;;
+
+    \?)
+    err_exit "Invalid Option: -$OPTARG" 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+echo ''
+echo "ENVIRONMENT VARIABLES..."
+env
+echo ''
+
+echo 'DOCKER VERSION...'
+docker --version
+docker-compose --version
+echo ''
+
+# Override docker compose environments
+echo 'DOCKER-COMPOSE COMMAND...'
+docker_compose_command='docker-compose -f docker-compose.yml '
+
+# Use CI environment
+if [ ! -z ${ci} ]; then
+  echo "...Using CI Environment with E2ETESTS_IMAGE: [${E2ETESTS_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
+fi
+
+# Use the mock application as the target of the e2e tests
+if [ ! -z ${usemock} ]; then
+  echo "...Using Mock app with MOCK_IMAGE: [${MOCK_IMAGE}] as Target with E2ETESTS_IMAGE: [${E2ETESTS_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.mock.yml "
+fi
+
+# Use the dev environment
+if [ ! -z ${devenv} ]; then
+  echo "...Using Development Environment with  with E2ETESTS_IMAGE: [${E2ETESTS_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
+fi
+echo "...COMMAND: [${docker_compose_command}]"
+echo ''
+
+echo 'DOCKER-COMPOSE CONFIGURATION...'
+$docker_compose_command config
+echo ''
+
+echo 'DOCKER-COMPOSE PULLING...'
+set +e
+$docker_compose_command pull
+echo '...Allowing pull errors (for local images)'
+set -e
+echo ''
+
+echo 'DOCKER IMAGES...'
+docker images
+echo ''
+
+echo "DOCKER-COMPOSE RUNNING [$@]..."
+# Allow to fail but catch return code
+set +e
+$docker_compose_command run --rm e2etests "$@"
+run_return_code=$?
+# NOTE return code must be caught before any other command
+set -e
+echo ''
+
+if [ $run_return_code -eq 0 ]; then
+    run_disposition='PASSED'
+else
+    run_disposition='FAILED'
+fi
+echo "...RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
+echo ''
+
+echo 'DOCKER-COMPOSE DOWN...'
+$docker_compose_command down
+echo ''
+
+echo "EXITING WITH ${run_disposition} RUN RETURN CODE ${run_return_code}"
+exit $run_return_code


### PR DESCRIPTION
# What
This changeset adds a docker compose framework to the project to support the usage and development of the tests as well as the development of the target `random_thought_api` application.  It also adds Continuous Integration (CI) using GitHub Actions to build, push and vet images of this project.  Both the docker compose framework and CI workflows are based on prior art of those used in my other projects.

To vet the e2e test images (deploy and development environment), the tests are run against the Mock application [mock_random_thoughts_api](https://github.com/brianjbayer/mock_random_thoughts_api).

# Why
Running in a containerized environment reduces variability associated with the operating environment and increases ease of use.  Continuous Integration with building, pushing, and vetting the images for linting, security, and successful execution of the tests reduces manual effort and better ensures quality and security. 

# Change Impact Analysis and Testing
Added docker compose framework verified by...
- [x] Successful execution of framework used in CI
- [x] Manual testing of remaining framework paths not executed in CI (using README documentation)

Added Continuous Integration workflows verified by...
- [x] Successful execution of the CI with manual inspection of the output of that execution

Documentation updates verified by...
- [x] Manual inspection of README on branch
- [x] Execution of documented added commands

