### PR TITLE
Add Properly Failing Test: Add Expect Database Migrations Field in /readyz Response

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -77,7 +77,6 @@ jobs:
     needs:
       - vet-code-standards
       - vet-dependency-security
-      - vet-deploy-e2e-tests
       - pr-norm-branch
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:

--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -8,8 +8,9 @@ services:
         condition: service_healthy
 
   mock:
-  # NOTE: Pin tag to ensure version matching between tests and mock
-    image: ${MOCK_IMAGE:-brianjbayer/mock_random_thoughts_api:930220310635932c4e40c442ce6db9f81af11cc7}
+  # NOTE: The failing test should be written first, so always go against
+  # latests version of the mock target to ensure currency of target
+    image: ${MOCK_IMAGE:-brianjbayer/mock_random_thoughts_api:latest}
     container_name: ${MOCK_HOSTNAME:-mock}
     environment:
       - PORT=${MOCK_PORT:-3000}

--- a/spec/health_checks/ready_check_spec.rb
+++ b/spec/health_checks/ready_check_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe '/readyz' do
     {
       'status' => 200,
       'message' => 'ready',
-      'database_connection' => 'ok'
+      'database_connection' => 'ok',
+      'database_migrations' => 'ok'
     }
   end
 end


### PR DESCRIPTION
# What
This changeset adds the to-be-developed expected behavior of the inclusion of the `"database_migrations": "ok"` field and value in the `random_thoughts_api` `\readyz` endpoint response.

This changeset also adjusts the workflow associated with running these tests as part of the experiment and experience of now updating behavior, specifically...
- The mock target is changed to the `latest` tag instead of being pinned
- The passing of these tests is dropped as a vetting requirement for the vetted image 

# Why
This is part of the experiment with an application, mock, and e2e test suite and how they should work being separate with development of behavior with the application.  This changeset of adding the properly failing test follows the test driven development approach of writing the failing test first.  Thus this repository will have the failing check which is the proper behavior given that the test is failing properly (e.g. failing because the to-be-developed expected behavior is missing).

# Change Impact Analysis and Testing

- [x] Verify that the test for the to-be-developed expected behavior is failing in the proper manner (i.e. the  `"database_migrations": "ok"` field and value are missing in the response and is detected as such)
- [x] Verify by running against a target with the expected behavior on a branch, that the test passes
