### PR TITLE
Add an E2E Tests Reusable Workflow

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -59,12 +59,11 @@ jobs:
     needs:
       - image-names
       - buildx-and-push-unvetted-image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun unvetted image e2e tests
-        run: "E2ETESTS_IMAGE=${{ needs.image-names.outputs.unvetted_image }} ./script/dockercomposerun -c"
+    uses: ./.github/workflows/run_e2e_tests.yml
+    with:
+      e2e_tests_image: ${{ needs.image-names.outputs.unvetted_image }}
 
+  # Custom workflow for dev image
   vet-dev-e2e-tests:
     name: Run Devenv E2E Tests
     needs:
@@ -72,7 +71,7 @@ jobs:
       - buildx-and-push-dev-image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: dockercomposerun devenv image e2e tests
         run: "E2ETESTS_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -d ./script/run tests"
 

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -1,0 +1,43 @@
+name: Run Random Thoughts API End-to-End Tests
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      e2e_tests_image:
+        description: "Non-default End-to-End tests image to run"
+        required: false
+        type: string
+      e2e_tests_command_prefix:
+        description: "Command line prefix to add before e2e test command"
+        required: false
+        type: string
+      workflow_checkout_ref:
+        description: "The ref to checkout for the scripts used in the workflow"
+        required: false
+        type: string
+        # NOTE: Version the scripts for this workflow here
+        default: v0.1
+
+jobs:
+  e2e-tests:
+    name: End-to-End Tests
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - name: Checkout e2e tests repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.workflow_checkout_ref }}
+          repository: brianjbayer/random_thoughts_api_e2e
+      - name: dockercomposerun e2e tests image
+        if: ${{ inputs.e2e_tests_image }}
+        run: "${{ inputs.e2e_tests_command_prefix }} E2ETESTS_IMAGE=${{ inputs.e2e_tests_image }} ./script/dockercomposerun -c"
+
+      - name: dockercomposerun e2e tests
+        if: ${{ ! inputs.e2e_tests_image }}
+        run: "${{ inputs.e2e_tests_command_prefix }} ./script/dockercomposerun"


### PR DESCRIPTION
# What & Why
This changeset adds a GitHub Actions Reusable Workflow `run_e2e_tests` for running the Deployment Image of these E2E Tests.  The workflow provides an input for a command-line prefix to the command used to run the tests for overriding environment variables such as the app-under-test image.  It also has an input for the workflows script version (`ref`).
 
# Change Impact Analysis and Testing
This is almost solely additive other than changing the PR workflow to use this new workflow for the Deploy image.

Verified this workflow works in this repository....
- [x] PR Checks vets the new workflow functionality and that there are no regressions
  - [x] Verified version `v0.1`

Verified this workflow is reusable and can be called in another repository....

- [x] brianjbayer/random_thoughts_api#102